### PR TITLE
Add http/https port option as part of create

### DIFF
--- a/pkg/minc/types/types.go
+++ b/pkg/minc/types/types.go
@@ -4,6 +4,8 @@ type CreateType struct {
 	Provider      string
 	UShiftVersion string
 	UShiftConfig  string
+	HTTPSPort     int
+	HTTPPort      int
 }
 
 type StatusType struct {

--- a/pkg/providers/moby/provider.go
+++ b/pkg/providers/moby/provider.go
@@ -54,8 +54,15 @@ func (p *provider) Create(cType *types.CreateType) error {
 	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
 		return err
 	}
+	rOptions := &providers.ROptions{
+		ContainerName: constants.ContainerName,
+		ImageName:     constants.GetUShiftImage(cType.UShiftVersion),
+		UShiftConfig:  cType.UShiftConfig,
+		HttpPort:      cType.HTTPPort,
+		HttpsPort:     cType.HTTPSPort,
+	}
 	cmd := exec.Command("docker",
-		providers.RunOptions(constants.ContainerName, constants.GetUShiftImage(cType.UShiftVersion), cType.UShiftConfig)...,
+		providers.RunOptions(rOptions)...,
 	)
 	out, err := exec.Output(cmd)
 	if err != nil {

--- a/pkg/providers/podman/provider.go
+++ b/pkg/providers/podman/provider.go
@@ -59,7 +59,14 @@ func (p *provider) Create(cType *types.CreateType) error {
 	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
 		return err
 	}
-	cmd := podmanCmd(providers.RunOptions(constants.ContainerName, constants.GetUShiftImage(cType.UShiftVersion), cType.UShiftConfig))
+	rOptions := &providers.ROptions{
+		ContainerName: constants.ContainerName,
+		ImageName:     constants.GetUShiftImage(cType.UShiftVersion),
+		UShiftConfig:  cType.UShiftConfig,
+		HttpPort:      cType.HTTPPort,
+		HttpsPort:     cType.HTTPSPort,
+	}
+	cmd := podmanCmd(providers.RunOptions(rOptions))
 	out, err := exec.Output(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
User can now change the http/https port which is used in container to expose routes port
```
 ./minc_linux_amd64 create --https-port 443 --http-port 80
```