### PR TITLE
feat(cli): Added support for using a custom container image for creating the microshift instance

### DIFF
--- a/cmd/minc/main.go
+++ b/cmd/minc/main.go
@@ -3,15 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"github.com/minc-org/minc/pkg/constants"
 	"github.com/minc-org/minc/pkg/log"
 	"github.com/minc-org/minc/pkg/minc"
 	"github.com/minc-org/minc/pkg/minc/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 var (
@@ -21,6 +22,7 @@ var (
 	uShiftConfig  string
 	httpsPort     string
 	httpPort      string
+	uShiftImage   string
 )
 
 var createCmd = &cobra.Command{
@@ -46,6 +48,7 @@ var createCmd = &cobra.Command{
 		cType := &types.CreateType{
 			Provider:      viper.GetString("provider"),
 			UShiftVersion: viper.GetString("microshift-version"),
+			UShiftImage:   viper.GetString("microshift-image"),
 			UShiftConfig:  uShiftConf,
 			HTTPSPort:     hsPort,
 			HTTPPort:      hPort,
@@ -168,6 +171,8 @@ func main() {
 	// create command flags
 	createCmd.PersistentFlags().StringVarP(&uShiftVersion, "microshift-version", "m", "",
 		fmt.Sprintf("MicroShift version to use, check available tag %s", constants.GetImageRegistry()))
+	createCmd.PersistentFlags().StringVarP(&uShiftImage, "microshift-image", "i", "",
+		"MicroShift image to use if default image registry is not to be used")
 	createCmd.PersistentFlags().StringVarP(&uShiftConfig, "microshift-config", "c", "",
 		"MicroShift custom config file")
 	createCmd.PersistentFlags().StringVar(&httpsPort, "https-port", "9443",
@@ -187,6 +192,7 @@ func main() {
 	viper.BindPFlag("provider", rootCmd.PersistentFlags().Lookup("provider"))
 	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
 	viper.BindPFlag("microshift-version", createCmd.PersistentFlags().Lookup("microshift-version"))
+	viper.BindPFlag("microshift-image", createCmd.PersistentFlags().Lookup("microshift-image"))
 	viper.BindPFlag("microshift-config", createCmd.PersistentFlags().Lookup("microshift-config"))
 	viper.BindPFlag("https-port", createCmd.PersistentFlags().Lookup("https-port"))
 	viper.BindPFlag("http-port", createCmd.PersistentFlags().Lookup("http-port"))

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -23,6 +23,9 @@ func GetImageRegistry() string {
 	return fmt.Sprintf("%s/%s/%s", Registry, RegistryOrg, ImageName)
 }
 
-func GetUShiftImage(version string) string {
+func GetUShiftImage(image, version string) string {
+	if image != "" {
+		return fmt.Sprintf("%s:%s-%s", image, version, runtime.GOARCH)
+	}
 	return fmt.Sprintf("%s:%s-%s", GetImageRegistry(), version, runtime.GOARCH)
 }

--- a/pkg/minc/create.go
+++ b/pkg/minc/create.go
@@ -2,6 +2,8 @@ package minc
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/minc-org/minc/pkg/cluster"
 	"github.com/minc-org/minc/pkg/constants"
 	"github.com/minc-org/minc/pkg/kubeconfig"
@@ -9,7 +11,6 @@ import (
 	"github.com/minc-org/minc/pkg/minc/types"
 	"github.com/minc-org/minc/pkg/providers/register"
 	"github.com/minc-org/minc/pkg/spinner"
-	"time"
 )
 
 func Create(cType *types.CreateType) error {
@@ -18,7 +19,7 @@ func Create(cType *types.CreateType) error {
 		return err
 	}
 	log.Debug("Provider Info", "Provider", p)
-	img := constants.GetUShiftImage(cType.UShiftVersion)
+	img := constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion)
 	log.Info(fmt.Sprintf("Ensuring cluster image (%s) ...", img))
 	s := spinner.New(time.Second)
 	s.Start()

--- a/pkg/minc/types/types.go
+++ b/pkg/minc/types/types.go
@@ -3,6 +3,7 @@ package types
 type CreateType struct {
 	Provider      string
 	UShiftVersion string
+	UShiftImage   string
 	UShiftConfig  string
 	HTTPSPort     int
 	HTTPPort      int

--- a/pkg/providers/moby/provider.go
+++ b/pkg/providers/moby/provider.go
@@ -3,9 +3,10 @@ package moby
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/minc-org/minc/pkg/minc/types"
 	"strings"
 	"time"
+
+	"github.com/minc-org/minc/pkg/minc/types"
 
 	"github.com/minc-org/minc/pkg/constants"
 	"github.com/minc-org/minc/pkg/exec"
@@ -72,7 +73,7 @@ func (p *provider) Create(cType *types.CreateType) error {
 	if out, _ := p.List(); len(out) == 0 {
 		cOptions := &providers.COptions{
 			ContainerName: constants.ContainerName,
-			ImageName:     constants.GetUShiftImage(cType.UShiftVersion),
+			ImageName:     constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
 			UShiftConfig:  cType.UShiftConfig,
 			HttpPort:      cType.HTTPPort,
 			HttpsPort:     cType.HTTPSPort,

--- a/pkg/providers/podman/provider.go
+++ b/pkg/providers/podman/provider.go
@@ -3,12 +3,13 @@ package podman
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/minc-org/minc/pkg/minc/types"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/minc-org/minc/pkg/minc/types"
 
 	"github.com/minc-org/minc/pkg/constants"
 	"github.com/minc-org/minc/pkg/exec"
@@ -74,7 +75,7 @@ func (p *provider) Create(cType *types.CreateType) error {
 	if out, _ := p.List(); len(out) == 0 {
 		cOptions := &providers.COptions{
 			ContainerName: constants.ContainerName,
-			ImageName:     constants.GetUShiftImage(cType.UShiftVersion),
+			ImageName:     constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
 			UShiftConfig:  cType.UShiftConfig,
 			HttpPort:      cType.HTTPPort,
 			HttpsPort:     cType.HTTPSPort,


### PR DESCRIPTION
For enabling optional components, it is required for us to use a custom container image, where the rpms of `microshift-olm` and `microshift-gitops` are installed. This requires the ability for the `minc` binary to be able to use custom images.

Fixes https://github.com/minc-org/minc/issues/47