### PR TITLE
feat(cli): Added support for including custom pull-secret to be used for the microshift instance

### DIFF
--- a/cmd/minc/main.go
+++ b/cmd/minc/main.go
@@ -3,24 +3,26 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"github.com/minc-org/minc/pkg/constants"
 	"github.com/minc-org/minc/pkg/log"
 	"github.com/minc-org/minc/pkg/minc"
 	"github.com/minc-org/minc/pkg/minc/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 var (
-	provider      string
-	logLevel      string
-	uShiftVersion string
-	uShiftConfig  string
-	httpsPort     string
-	httpPort      string
+	provider         string
+	logLevel         string
+	uShiftVersion    string
+	uShiftConfig     string
+	uShiftPullSecret string
+	httpsPort        string
+	httpPort         string
 )
 
 var createCmd = &cobra.Command{
@@ -44,11 +46,12 @@ var createCmd = &cobra.Command{
 		}
 
 		cType := &types.CreateType{
-			Provider:      viper.GetString("provider"),
-			UShiftVersion: viper.GetString("microshift-version"),
-			UShiftConfig:  uShiftConf,
-			HTTPSPort:     hsPort,
-			HTTPPort:      hPort,
+			Provider:         viper.GetString("provider"),
+			UShiftVersion:    viper.GetString("microshift-version"),
+			UShiftConfig:     uShiftConf,
+			UShiftPullSecret: viper.GetString("microshift-pull-secret"),
+			HTTPSPort:        hsPort,
+			HTTPPort:         hPort,
 		}
 		err = minc.Create(cType)
 		if err != nil {
@@ -170,6 +173,8 @@ func main() {
 		fmt.Sprintf("MicroShift version to use, check available tag %s", constants.GetImageRegistry()))
 	createCmd.PersistentFlags().StringVarP(&uShiftConfig, "microshift-config", "c", "",
 		"MicroShift custom config file")
+	createCmd.PersistentFlags().StringVarP(&uShiftPullSecret, "microshift-pull-secret", "s", "",
+		"Path to local pull secret file. This secret can be downloaded from https://console.redhat.com/openshift/install/pull-secret")
 	createCmd.PersistentFlags().StringVar(&httpsPort, "https-port", "9443",
 		"https route port to be exposed by container (default: 9443)")
 	createCmd.PersistentFlags().StringVar(&httpPort, "http-port", "9080",

--- a/pkg/minc/types/types.go
+++ b/pkg/minc/types/types.go
@@ -1,11 +1,12 @@
 package types
 
 type CreateType struct {
-	Provider      string
-	UShiftVersion string
-	UShiftConfig  string
-	HTTPSPort     int
-	HTTPPort      int
+	Provider         string
+	UShiftVersion    string
+	UShiftConfig     string
+	UShiftPullSecret string
+	HTTPSPort        int
+	HTTPPort         int
 }
 
 type StatusType struct {

--- a/pkg/providers/options.go
+++ b/pkg/providers/options.go
@@ -2,15 +2,17 @@ package providers
 
 import (
 	"fmt"
+
 	"github.com/minc-org/minc/pkg/constants"
 )
 
 type COptions struct {
-	ContainerName string
-	ImageName     string
-	UShiftConfig  string
-	HttpPort      int
-	HttpsPort     int
+	ContainerName    string
+	ImageName        string
+	UShiftConfig     string
+	UShiftPullSecret string
+	HttpPort         int
+	HttpsPort        int
 }
 
 func CreateOptions(r *COptions) []string {
@@ -37,6 +39,11 @@ func CreateOptions(r *COptions) []string {
 	if r.UShiftConfig != "" {
 		createOptions = append(createOptions, "-v",
 			fmt.Sprintf("%s:/etc/microshift/config.d/00-custom-config.yaml:ro,rshared", r.UShiftConfig))
+	}
+
+	if r.UShiftPullSecret != "" {
+		createOptions = append(createOptions, "-v",
+			fmt.Sprintf("%s:/etc/crio/openshift-pull-secret:ro,rshared", r.UShiftPullSecret))
 	}
 
 	return append(createOptions,

--- a/pkg/providers/podman/provider.go
+++ b/pkg/providers/podman/provider.go
@@ -3,12 +3,13 @@ package podman
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/minc-org/minc/pkg/minc/types"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/minc-org/minc/pkg/minc/types"
 
 	"github.com/minc-org/minc/pkg/constants"
 	"github.com/minc-org/minc/pkg/exec"
@@ -73,11 +74,12 @@ func (p *provider) Create(cType *types.CreateType) error {
 	}
 	if out, _ := p.List(); len(out) == 0 {
 		cOptions := &providers.COptions{
-			ContainerName: constants.ContainerName,
-			ImageName:     constants.GetUShiftImage(cType.UShiftVersion),
-			UShiftConfig:  cType.UShiftConfig,
-			HttpPort:      cType.HTTPPort,
-			HttpsPort:     cType.HTTPSPort,
+			ContainerName:    constants.ContainerName,
+			ImageName:        constants.GetUShiftImage(cType.UShiftVersion),
+			UShiftConfig:     cType.UShiftConfig,
+			UShiftPullSecret: cType.UShiftPullSecret,
+			HttpPort:         cType.HTTPPort,
+			HttpsPort:        cType.HTTPSPort,
 		}
 		cmd := podmanCmd(providers.CreateOptions(cOptions))
 		out, err := exec.Output(cmd)


### PR DESCRIPTION
Pull secrets are required for pulling container images from private registries. When enabling optional components like `microshift-olm` and `microshift-gitops` which requires images to be pulled from `registry.redhat.io` or similar private repositories in `quay.io`. Without mounting these pull-secret file, these components will fail to get initialized and pods will go into a `ImagePullBackOff` error without any recovery.

The fix is to avoid such image pull errors and be able to use the optional MicroShift Components - `microshift-olm` and `microshift-gitops`

Fixes https://github.com/minc-org/minc/issues/48
### Test results
```
~/go/bin/minc create --microshift-pull-secret ~/.pull-secret.json
[sudo] password for anjoseph: 
time=2025-08-18T07:32:36.161+05:30 level=INFO msg="Ensuring cluster image (quay.io/minc-org/minc:4.19.0-okd-scos.7-amd64) ..."
\time=2025-08-18T07:34:27.595+05:30 level=INFO msg="Waiting for MicroShift service to start..."
\time=2025-08-18T07:35:11.424+05:30 level=INFO msg="Waiting for KubeConfig ..."
time=2025-08-18T07:35:11.657+05:30 level=INFO msg="Waiting for pods to be ready..."
time=2025-08-18T07:35:11.989+05:30 level=INFO msg="Cluster created"
```
Once the Microshift instance is up, check for the mounted pull secret as below
```
# sudo podman exec -it $(sudo podman ps --noheading | awk '{print$1}')  ls -ld /etc/crio/openshift-pull-secret 
-rw-r--r--. 1 root root 2775 Aug  8 04:13 /etc/crio/openshift-pull-secret
# sudo podman exec -it $(sudo podman ps --noheading | awk '{print$1}') cat /etc/crio/openshift-pull-secret | jq
{
  "auths": {
    "cloud.openshift.com": {
      "auth": "<redacted>"
    },
    "quay.io": {
      "auth": "<redacted>",
      "email": "example@example.com"
    },
    "registry.redhat.io": {
      "auth": "<redacted>",
      "email": "example@example.com"
    }
  }
}
```
