### PR TITLE
Add volume option for docker with read-write permissions

### DIFF
--- a/pkg/providers/moby/provider.go
+++ b/pkg/providers/moby/provider.go
@@ -77,6 +77,7 @@ func (p *provider) Create(cType *types.CreateType) error {
 			UShiftConfig:  cType.UShiftConfig,
 			HttpPort:      cType.HTTPPort,
 			HttpsPort:     cType.HTTPSPort,
+			VolumeOption:  "/var/lib/docker:/host-container:rw,rshared",
 		}
 		cmd := exec.Command("docker",
 			providers.CreateOptions(cOptions)...,

--- a/pkg/providers/options.go
+++ b/pkg/providers/options.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"fmt"
+
 	"github.com/minc-org/minc/pkg/constants"
 )
 
@@ -11,6 +12,7 @@ type COptions struct {
 	UShiftConfig  string
 	HttpPort      int
 	HttpsPort     int
+	VolumeOption  string
 }
 
 func CreateOptions(r *COptions) []string {
@@ -29,7 +31,7 @@ func CreateOptions(r *COptions) []string {
 		"--hostname", constants.HostName,
 		"--label", fmt.Sprintf("%s=%s", constants.LabelKey, r.ContainerName),
 		"-it", "--privileged",
-		"-v", "/var/lib/containers/storage:/host-container:ro,rshared",
+		"-v", r.VolumeOption,
 		"-p", fmt.Sprintf(httpPortOption, r.HttpPort),
 		"-p", fmt.Sprintf(httpsPortOption, r.HttpsPort),
 		"-p", "127.0.0.1:6443:6443",

--- a/pkg/providers/podman/provider.go
+++ b/pkg/providers/podman/provider.go
@@ -79,6 +79,7 @@ func (p *provider) Create(cType *types.CreateType) error {
 			UShiftConfig:  cType.UShiftConfig,
 			HttpPort:      cType.HTTPPort,
 			HttpsPort:     cType.HTTPSPort,
+			VolumeOption:  "/var/lib/containers/storage:/host-container:ro,rshared",
 		}
 		cmd := podmanCmd(providers.CreateOptions(cOptions))
 		out, err := exec.Output(cmd)


### PR DESCRIPTION
The location /var/lib/containers/storage is only relevant for podman to share overlays between host and container. Docker uses overlay2 and that's why overlay sharing won't work.

By specifying /var/lib/docker for docker with the read-write option the /host-container volume mount is available and can be used for the lock files of the overlay-images and overlay-layers.