### PR TITLE
🐛 Fix: Support Docker and non-Linux environments with optional overlay cache

### DIFF
--- a/cmd/minc/config.go
+++ b/cmd/minc/config.go
@@ -17,12 +17,13 @@ var configCmd = &cobra.Command{
 
 // defaultConfig holds all the default configuration values
 var defaultConfig = map[string]interface{}{
-	"provider":           "podman",
-	"log-level":          "info",
-	"microshift-version": constants.UShiftVersion,
-	"https-port":         "9443",
-	"http-port":          "9080",
-	"microshift-config":  "",
+	"provider":              "podman",
+	"log-level":             "info",
+	"microshift-version":    constants.UShiftVersion,
+	"https-port":            "9443",
+	"http-port":             "9080",
+	"microshift-config":     "",
+	"disable-overlay-cache": false,
 }
 
 // getDefaults returns the default configuration values

--- a/pkg/minc/types/types.go
+++ b/pkg/minc/types/types.go
@@ -1,12 +1,13 @@
 package types
 
 type CreateType struct {
-	Provider      string
-	UShiftVersion string
-	UShiftImage   string
-	UShiftConfig  string
-	HTTPSPort     int
-	HTTPPort      int
+	Provider            string
+	UShiftVersion       string
+	UShiftImage         string
+	UShiftConfig        string
+	HTTPSPort           int
+	HTTPPort            int
+	DisableOverlayCache bool
 }
 
 type StatusType struct {

--- a/pkg/providers/moby/provider.go
+++ b/pkg/providers/moby/provider.go
@@ -72,11 +72,12 @@ func (p *provider) Create(cType *types.CreateType) error {
 	}
 	if out, _ := p.List(); len(out) == 0 {
 		cOptions := &providers.COptions{
-			ContainerName: constants.ContainerName,
-			ImageName:     constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
-			UShiftConfig:  cType.UShiftConfig,
-			HttpPort:      cType.HTTPPort,
-			HttpsPort:     cType.HTTPSPort,
+			ContainerName:       constants.ContainerName,
+			ImageName:           constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
+			UShiftConfig:        cType.UShiftConfig,
+			HttpPort:            cType.HTTPPort,
+			HttpsPort:           cType.HTTPSPort,
+			DisableOverlayCache: cType.DisableOverlayCache,
 		}
 		cmd := exec.Command("docker",
 			providers.CreateOptions(cOptions)...,

--- a/pkg/providers/podman/provider.go
+++ b/pkg/providers/podman/provider.go
@@ -74,11 +74,12 @@ func (p *provider) Create(cType *types.CreateType) error {
 	}
 	if out, _ := p.List(); len(out) == 0 {
 		cOptions := &providers.COptions{
-			ContainerName: constants.ContainerName,
-			ImageName:     constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
-			UShiftConfig:  cType.UShiftConfig,
-			HttpPort:      cType.HTTPPort,
-			HttpsPort:     cType.HTTPSPort,
+			ContainerName:       constants.ContainerName,
+			ImageName:           constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
+			UShiftConfig:        cType.UShiftConfig,
+			HttpPort:            cType.HTTPPort,
+			HttpsPort:           cType.HTTPSPort,
+			DisableOverlayCache: cType.DisableOverlayCache,
 		}
 		cmd := podmanCmd(providers.CreateOptions(cOptions))
 		out, err := exec.Output(cmd)


### PR DESCRIPTION
## Fix: Support Docker and non-Linux environments with optional overlay cache

### Problem

The current implementation uses a hardcoded mount `/var/lib/containers/storage:/host-container:ro,rshared` which works well with Podman on Linux but fails on:
- **Docker** (both Linux and non-Linux), not tested on Linux, this is an assumption.
- **macOS/Windows** with Docker Desktop or OrbStack (where the path doesn't exist in the underlying VM)

This causes a pod creation failure with the error:
```
loading additional layer stores: creating lock file directory:
mkdir /host-container/overlay-layers: read-only file system
```

### Solution

This PR introduces an optional `--disable-overlay-cache` flag that:
- **Disables the hardcoded host mount** when specified
- **Uses a named Docker/Podman volume instead** to satisfy CRI-O's requirements, 
I tried removing the mount entierely, but, CRI-O fails and the cluster doesn't start.
- **Maintains backward compatibility** - existing Podman on Linux users are unaffected (default behavior unchanged)

This allows minC to work seamlessly across different container runtimes and operating systems.

### Testing

**macOS with Docker:**
- ✅ `./minc create --disable-overlay-cache -p docker` → **Works**
- ❌ `./minc create -p docker` → **Fails** with read-only filesystem error

The flag successfully bypasses the problematic mount while keeping CRI-O functional.

### Discussion

An alternative approach would be to mount the volume in **read-write (RW) mode** instead of read-only (RO), allowing the container to create the `.lock` file if it doesn't exist. 

**I'd appreciate the maintainer's input on this approach** - would RW be acceptable, or is the named volume solution preferable for security/isolation reasons?

### Technical Details

For reference, on macOS/Windows, the [workaround](https://github.com/orbstack/orbstack/issues/435#issuecomment-1630764091) to create the overlay structure would be:
```bash
docker run --rm --privileged -v /:/host alpine sh -c \
  "mkdir -p /host/var/lib/containers/storage/overlay-layers && \
   touch /host/var/lib/containers/storage/overlay-layers/layers.lock"
```
Because, on macOS/Windows, the `/` path in containers refers to the VM's filesystem, not the host, making the hardcoded path empty.

However, this is complex and requires privileged access, making the named volume approach cleaner, and on linux mounting / would be scary.

### Conclusion

i saw other proposal PR to find the correct path, this would ultimately be the best, but this is kinda blocking us for some activities, hence this proposal. Also it allows to create a cluster really separated from the host in terms of images, which might be interesting ?