### PR TITLE
feat: Add --allow-rootless flag for rootless Podman support

### DIFF
--- a/.github/workflows/linux_test_rootless.yml
+++ b/.github/workflows/linux_test_rootless.yml
@@ -1,0 +1,101 @@
+name: Linux Test Rootless Podman
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23
+
+      - name: Build binary
+        run: make install
+
+      - name: Apply rootless host prerequisites
+        run: |
+          sudo sysctl -w net.ipv4.ip_forward=1
+          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80
+          sudo sysctl -w fs.inotify.max_user_instances=1024
+          sudo modprobe ip_tables
+          sudo mkdir -p /etc/systemd/system/user@.service.d/
+          cat <<'EOF' | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
+          [Service]
+          Delegate=cpuset cpu io memory pids
+          EOF
+          sudo systemctl daemon-reload
+          # Replace existing subuid/subgid entry to avoid overlapping ranges
+          # which cause newuidmap to fail with EINVAL
+          sudo sed -i "/^$(whoami):/d" /etc/subuid /etc/subgid
+          echo "$(whoami):100000:1100000000" | sudo tee -a /etc/subuid
+          echo "$(whoami):100000:1100000000" | sudo tee -a /etc/subgid
+          podman system migrate
+
+      - name: Run rootless cluster
+        run: |
+          minc create --allow-rootless --log-level debug
+          minc status
+
+      - name: Test stop and recreate
+        run: |
+          podman stop microshift
+          minc status
+          minc create --allow-rootless
+          minc status
+
+      - name: Install oc
+        shell: bash
+        run: |
+          if [ ${{ runner.arch }} = "X64" ]; then
+            OC_ARCH="amd64"
+            URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz"
+          else
+            OC_ARCH="arm64"
+            URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-${OC_ARCH}.tar.gz"
+          fi
+          FILENAME="openshift-client-linux-${OC_ARCH}.tar.gz"
+          echo "Downloading $URL"
+          curl -H user-agent:minc-ci -L "$URL" -o openshift-client-linux-${OC_ARCH}.tar.gz --max-time 300 --fail
+          tar -xzf "$FILENAME"
+          sudo mv oc kubectl /usr/bin/
+
+      - name: Test if generate kubeconfig works as expected
+        shell: bash
+        run: |
+          oc config get-contexts
+          oc config delete-context microshift
+          minc generate-kubeconfig
+          oc config get-contexts
+          oc get pods -A
+
+      - name: Test the sample app
+        run: |
+          podman build -t quay.io/praveenkumar/myserver:v1 https://github.com/praveenkumar/simple-go-server.git
+          oc apply -f https://raw.githubusercontent.com/praveenkumar/simple-go-server/refs/heads/main/kubernetes/deploy.yaml
+          oc get pods -n demo
+          oc wait --for=jsonpath='{.status.phase}'=Running pod/myserver -n demo
+          oc expose svc myserver -n demo
+          oc get routes -n demo
+          curl -Ik $(oc get route -n demo -ojsonpath='{.items[].spec.host}'):9080
+
+      - name: Delete cluster
+        run: |
+          minc delete
+          minc status

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Get the latest release from GitHub release page as per your platform.
 
 #### Linux
 
-In Linux, minc require sudo permission to run podman command because it is not working with rootless mode as of now.
-Check: https://github.com/minc-org/minc/issues/22
-
 ```bash
 curl -L -o minc  https://github.com/minc-org/minc/releases/latest/download/minc_linux_amd64
 chmod +x minc
 ```
+
+By default, minc requires sudo to run Podman commands. To run without
+sudo, see [Rootless Mode (Linux)](#rootless-mode-linux) below.
 
 #### Mac
 ```bash
@@ -104,10 +104,77 @@ minc config -h
 | `log-level`          | Log level (default: `info`)                                                                                                                           |
 | `provider`           | Container runtime provider, e.g., `docker`, `podman` (default: `podman`)                                                                              |
 | `https-port`         | Different port to use for exposing https service (default:`9443`)                                                                                     |
-| `http-port`          | Different port to use for exposing https service (default:`9080`)                                                                                     |
+| `http-port`          | Different port to use for exposing http service (default:`9080`)                                                                                      |
+| `allow-rootless`     | Use rootless Podman without sudo (default: `false`). See [Rootless Mode](#rootless-mode-linux)                                                        |
+| `disable-overlay-cache` | Disable container overlay storage cache mount (default: `false`)                                                                                  |
 
 
 Once the container is running, you can interact with the MicroShift cluster using `kubectl` or `oc` tools.
+
+## Rootless Mode (Linux)
+
+Minc can run without sudo using rootless Podman. This is experimental and
+requires a one-time host setup.
+
+### Host Prerequisites
+
+Steps 1-3 require root/sudo. All settings persist across reboots.
+
+**1. Kernel parameters (sysctl):**
+```bash
+sudo tee /etc/sysctl.d/99-minc-rootless.conf <<'EOF'
+net.ipv4.ip_forward = 1
+net.ipv4.ip_unprivileged_port_start = 80
+fs.inotify.max_user_instances = 1024
+EOF
+sudo sysctl --system
+```
+
+- `ip_forward` - required for container networking (packet forwarding)
+- `ip_unprivileged_port_start = 80` - allows rootless Podman to bind HTTP/HTTPS ports
+- `max_user_instances = 1024` - increases inotify watch limit for MicroShift services
+
+**2. Load `ip_tables` kernel module:**
+```bash
+sudo tee /etc/modules-load.d/minc-rootless.conf <<'EOF'
+ip_tables
+EOF
+sudo modprobe ip_tables
+```
+
+**3. Delegate cgroup controllers to user sessions:**
+```bash
+sudo mkdir -p /etc/systemd/system/user@.service.d/
+sudo tee /etc/systemd/system/user@.service.d/delegate.conf <<'EOF'
+[Service]
+Delegate=cpuset cpu io memory pids
+EOF
+sudo systemctl daemon-reload
+```
+
+**4. Expand subordinate UID/GID ranges** (required for OpenShift SCC UIDs):
+```bash
+sudo usermod --add-subuids 165536-1265535999 --add-subgids 165536-1265535999 $(whoami)
+```
+
+Then, as your regular user (not root), migrate Podman to pick up the new ranges:
+```bash
+podman system migrate
+```
+
+### Rootless Usage
+
+```bash
+# Create a rootless cluster:
+minc create --allow-rootless
+
+# Or set it persistently via config:
+minc config set allow-rootless true
+minc create
+
+# Delete (auto-detects rootless mode):
+minc delete
+```
 
 ## Contributing
 

--- a/cmd/minc/config.go
+++ b/cmd/minc/config.go
@@ -24,6 +24,7 @@ var defaultConfig = map[string]interface{}{
 	"http-port":             "9080",
 	"microshift-config":     "",
 	"disable-overlay-cache": false,
+	"allow-rootless":        false,
 }
 
 // getDefaults returns the default configuration values

--- a/cmd/minc/main.go
+++ b/cmd/minc/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/minc-org/minc/pkg/log"
 	"github.com/minc-org/minc/pkg/minc"
 	"github.com/minc-org/minc/pkg/minc/types"
+	"github.com/minc-org/minc/pkg/rootlessmarker"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -24,6 +25,7 @@ var (
 	httpPort            string
 	uShiftImage         string
 	disableOverlayCache bool
+	allowRootless       bool
 )
 
 var createCmd = &cobra.Command{
@@ -55,8 +57,19 @@ var createCmd = &cobra.Command{
 			HTTPPort:            hPort,
 			DisableOverlayCache: viper.GetBool("disable-overlay-cache"),
 		}
+		allowRL := viper.GetBool("allow-rootless")
+		if allowRL {
+			if err := rootlessmarker.Set(); err != nil {
+				log.Fatal("failed to record rootless mode", "err", err)
+			}
+		}
 		err = minc.Create(cType)
 		if err != nil {
+			if allowRL {
+				if rmErr := rootlessmarker.Remove(); rmErr != nil {
+					log.Error("failed to clear rootless marker after create failure", "err", rmErr)
+				}
+			}
 			log.Fatal("error creating cluster", "err", err)
 		}
 		log.Info("Cluster created")
@@ -95,6 +108,9 @@ var deleteCmd = &cobra.Command{
 		err := minc.Delete(viper.GetString("provider"))
 		if err != nil {
 			log.Fatal("error deleting cluster", "err", err)
+		}
+		if err := rootlessmarker.Remove(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: deleted cluster but failed to clear rootless marker: %v\n", err)
 		}
 		fmt.Println("Item deleted")
 	},
@@ -189,6 +205,8 @@ func main() {
 
 	rootCmd.PersistentFlags().StringVarP(&provider, "provider", "p", "", "Specify the provider (e.g., podman, docker)")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "", "Log level (e.g., info, debug, warn)")
+	rootCmd.PersistentFlags().BoolVar(&allowRootless, "allow-rootless", defaultConfig["allow-rootless"].(bool),
+		"Use rootless Podman (no sudo); experimental — MicroShift may not start")
 
 	// Add config subcommands
 	configCmd.AddCommand(configSetCmd, configGetCmd, configUnsetCmd, configViewCmd)
@@ -198,6 +216,7 @@ func main() {
 	// Binding with viper
 	viper.BindPFlag("provider", rootCmd.PersistentFlags().Lookup("provider"))
 	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	viper.BindPFlag("allow-rootless", rootCmd.PersistentFlags().Lookup("allow-rootless"))
 	viper.BindPFlag("microshift-version", createCmd.PersistentFlags().Lookup("microshift-version"))
 	viper.BindPFlag("microshift-image", createCmd.PersistentFlags().Lookup("microshift-image"))
 	viper.BindPFlag("microshift-config", createCmd.PersistentFlags().Lookup("microshift-config"))

--- a/pkg/providers/moby/provider.go
+++ b/pkg/providers/moby/provider.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/minc-org/minc/pkg/minc/types"
 
@@ -115,7 +114,7 @@ func (p *provider) WaitForMicroShiftService() error {
 		log.Debug(string(out))
 		return nil
 	}
-	return retry.Retry(cmdFunc, 15, 2*time.Second)
+	return retry.Retry(cmdFunc, providers.MicroShiftServiceMaxRetries, providers.MicroShiftServiceInitialRetryDelay)
 }
 
 func (p *provider) GetKubeConfig() ([]byte, error) {

--- a/pkg/providers/options.go
+++ b/pkg/providers/options.go
@@ -12,6 +12,25 @@ type COptions struct {
 	HttpPort            int
 	HttpsPort           int
 	DisableOverlayCache bool
+	// HostContainerStorage is the host path to the container engine's graph root (e.g. Podman Store.GraphRoot).
+	// When empty, the default rootful path /var/lib/containers/storage is used.
+	HostContainerStorage string
+	// AllowRootless enables rootless-specific container tweaks:
+	//  - sysctl net.ipv6.conf.all.disable_ipv6=1: etcd binds 127.0.0.1 only,
+	//    but glibc prefers ::1 for localhost (RFC 6724), causing kube-apiserver
+	//    to fail connecting to etcd.
+	//  - mount /dev/null as /dev/kmsg: kubelet needs /dev/kmsg for the OOM
+	//    watcher, which is inaccessible in rootless user namespaces.
+	AllowRootless bool
+	// RootlessMicroShiftConfig is the host path to a MicroShift config.d YAML
+	// that enables KubeletInUserNamespace and other rootless settings.
+	RootlessMicroShiftConfig string
+	// RootlessCRIOConfig is the host path to a CRI-O config drop-in that
+	// switches the cgroup manager to cgroupfs for rootless operation.
+	RootlessCRIOConfig string
+	// RootlessCrunWrapper is the host path to a crun wrapper script that
+	// forces --rootless mode so crun skips oom_score_adj writes.
+	RootlessCrunWrapper string
 }
 
 func CreateOptions(r *COptions) []string {
@@ -34,18 +53,40 @@ func CreateOptions(r *COptions) []string {
 		"-p", fmt.Sprintf(httpsPortOption, r.HttpsPort),
 		"-p", "127.0.0.1:6443:6443",
 	}
-	
+
+	if r.AllowRootless {
+		createOptions = append(createOptions,
+			"--sysctl", "net.ipv6.conf.all.disable_ipv6=1",
+			"-v", "/dev/null:/dev/kmsg",
+		)
+		if r.RootlessMicroShiftConfig != "" {
+			createOptions = append(createOptions, "-v",
+				fmt.Sprintf("%s:/etc/microshift/config.d/20-rootless.yaml:ro", r.RootlessMicroShiftConfig))
+		}
+		if r.RootlessCRIOConfig != "" {
+			createOptions = append(createOptions, "-v",
+				fmt.Sprintf("%s:/etc/crio/crio.conf.d/20-rootless.conf:ro", r.RootlessCRIOConfig))
+		}
+		if r.RootlessCrunWrapper != "" {
+			createOptions = append(createOptions, "-v",
+				fmt.Sprintf("%s:/usr/local/bin/crun-rootless:ro", r.RootlessCrunWrapper))
+		}
+	}
+
 	// Handle overlay cache mount
 	if !r.DisableOverlayCache {
-		// Use host bind mount (default behavior for Linux)
-		createOptions = append(createOptions, "-v", "/var/lib/containers/storage:/host-container:ro,rshared")
+		hostPath := "/var/lib/containers/storage"
+		if r.HostContainerStorage != "" {
+			hostPath = r.HostContainerStorage
+		}
+		createOptions = append(createOptions, "-v", fmt.Sprintf("%s:/host-container:ro,rshared", hostPath))
 	} else {
 		// Use named volume for better macOS/Docker compatibility
 		// This allows CRI-O to function without accessing host storage
 		// Note: Named volumes don't support bind options like 'rshared'
 		createOptions = append(createOptions, "-v", "minc-container-storage:/host-container")
 	}
-	
+
 	// Mount custom MicroShift config if provided
 	if r.UShiftConfig != "" {
 		createOptions = append(createOptions, "-v",

--- a/pkg/providers/podman/provider.go
+++ b/pkg/providers/podman/provider.go
@@ -3,11 +3,11 @@ package podman
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/minc-org/minc/pkg/minc/types"
 
@@ -18,21 +18,41 @@ import (
 	"github.com/minc-org/minc/pkg/retry"
 )
 
-var useSudo bool
-var once sync.Once
-
 // Provider implements provider.Provider
-// see NewProvider
 type provider struct {
-	info *providers.ProviderInfo
+	info          *providers.ProviderInfo
+	useSudo       bool
+	allowRootless bool
 }
 
-func New() (providers.Provider, error) {
-	pInfo, err := getProviderInfo()
+// New builds a Podman provider. When allowRootless is true, minc stays on the user's rootless
+// Podman (no sudo) and skips the rootful-only guard; MicroShift may still fail at runtime.
+func New(allowRootless bool) (providers.Provider, error) {
+	rootlessRuntime, err := rootlessFromUserPodman()
 	if err != nil {
 		return nil, err
 	}
-	return &provider{pInfo}, nil
+	useSudo := rootlessRuntime && !allowRootless
+
+	p := &provider{
+		allowRootless: allowRootless,
+		useSudo:       useSudo,
+	}
+	info, err := p.fetchProviderInfo()
+	if err != nil {
+		return nil, err
+	}
+	p.info = info
+	return p, nil
+}
+
+func rootlessFromUserPodman() (bool, error) {
+	cmd := exec.Command("podman", "info", "--format", "{{.Host.Security.Rootless}}")
+	out, err := exec.Output(cmd)
+	if err != nil {
+		return false, err
+	}
+	return strconv.ParseBool(strings.TrimSpace(string(out)))
 }
 
 func (p *provider) Name() string {
@@ -40,11 +60,11 @@ func (p *provider) Name() string {
 }
 
 func (p *provider) Info() (*providers.ProviderInfo, error) {
-	return getProviderInfo()
+	return p.fetchProviderInfo()
 }
 
 func (p *provider) ImageExists(image string) bool {
-	cmd := podmanCmd(providers.ImageExistOptions(image))
+	cmd := p.podmanCmd(providers.ImageExistOptions(image))
 	_, err := exec.Output(cmd)
 	if err != nil {
 		return false
@@ -53,13 +73,13 @@ func (p *provider) ImageExists(image string) bool {
 }
 
 func (p *provider) PullImage(image string) error {
-	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
+	if err := p.checkCGroupsAndRootFulMode(); err != nil {
 		return err
 	}
 	if p.ImageExists(image) {
 		return nil
 	}
-	cmd := podmanCmd(providers.PullOptions(image))
+	cmd := p.podmanCmd(providers.PullOptions(image))
 	out, err := exec.Output(cmd)
 	if err != nil {
 		return err
@@ -68,27 +88,51 @@ func (p *provider) PullImage(image string) error {
 	return nil
 }
 
+func (p *provider) storeGraphRoot() (string, error) {
+	cmd := p.podmanCmd([]string{"info", "--format", "{{.Store.GraphRoot}}"})
+	out, err := exec.Output(cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 func (p *provider) Create(cType *types.CreateType) error {
-	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
+	if err := p.checkCGroupsAndRootFulMode(); err != nil {
 		return err
 	}
 	if out, _ := p.List(); len(out) == 0 {
-		cOptions := &providers.COptions{
-			ContainerName:       constants.ContainerName,
-			ImageName:           constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
-			UShiftConfig:        cType.UShiftConfig,
-			HttpPort:            cType.HTTPPort,
-			HttpsPort:           cType.HTTPSPort,
-			DisableOverlayCache: cType.DisableOverlayCache,
+		graphRoot, err := p.storeGraphRoot()
+		if err != nil {
+			return fmt.Errorf("podman store graph root: %w", err)
 		}
-		cmd := podmanCmd(providers.CreateOptions(cOptions))
+		cOptions := &providers.COptions{
+			ContainerName:        constants.ContainerName,
+			ImageName:            constants.GetUShiftImage(cType.UShiftImage, cType.UShiftVersion),
+			UShiftConfig:         cType.UShiftConfig,
+			HttpPort:             cType.HTTPPort,
+			HttpsPort:            cType.HTTPSPort,
+			DisableOverlayCache:  cType.DisableOverlayCache,
+			HostContainerStorage: graphRoot,
+			AllowRootless:        p.allowRootless,
+		}
+		if p.allowRootless {
+			rlConf, err := writeRootlessConfigs()
+			if err != nil {
+				return fmt.Errorf("writing rootless configs: %w", err)
+			}
+			cOptions.RootlessMicroShiftConfig = rlConf.microshiftConf
+			cOptions.RootlessCRIOConfig = rlConf.crioConf
+			cOptions.RootlessCrunWrapper = rlConf.crunWrapper
+		}
+		cmd := p.podmanCmd(providers.CreateOptions(cOptions))
 		out, err := exec.Output(cmd)
 		if err != nil {
 			return err
 		}
 		log.Debug(string(out))
 	}
-	cmd := podmanCmd(providers.StartOptions(constants.ContainerName))
+	cmd := p.podmanCmd(providers.StartOptions(constants.ContainerName))
 	out, err := exec.Output(cmd)
 	if err != nil {
 		return err
@@ -98,11 +142,11 @@ func (p *provider) Create(cType *types.CreateType) error {
 }
 
 func (p *provider) WaitForMicroShiftService() error {
-	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
+	if err := p.checkCGroupsAndRootFulMode(); err != nil {
 		return err
 	}
 	cmdFunc := func() error {
-		cmd := podmanCmd(providers.ServiceWaitOption("microshift", constants.ContainerName))
+		cmd := p.podmanCmd(providers.ServiceWaitOption("microshift", constants.ContainerName))
 		out, err := exec.Output(cmd)
 		if err != nil {
 			return err
@@ -111,22 +155,22 @@ func (p *provider) WaitForMicroShiftService() error {
 		log.Debug(string(out))
 		return nil
 	}
-	return retry.Retry(cmdFunc, 15, 2*time.Second)
+	return retry.Retry(cmdFunc, providers.MicroShiftServiceMaxRetries, providers.MicroShiftServiceInitialRetryDelay)
 }
 
 func (p *provider) GetKubeConfig() ([]byte, error) {
-	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
+	if err := p.checkCGroupsAndRootFulMode(); err != nil {
 		return nil, err
 	}
-	cmd := podmanCmd(providers.KubeConfigOption(constants.ContainerName, constants.HostName))
+	cmd := p.podmanCmd(providers.KubeConfigOption(constants.ContainerName, constants.HostName))
 	return exec.Output(cmd)
 }
 
 func (p *provider) Delete() error {
-	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
+	if err := p.checkCGroupsAndRootFulMode(); err != nil {
 		return err
 	}
-	cmd := podmanCmd(providers.DeleteOptions(constants.ContainerName))
+	cmd := p.podmanCmd(providers.DeleteOptions(constants.ContainerName))
 	out, err := exec.Output(cmd)
 	if err != nil {
 		return err
@@ -137,10 +181,10 @@ func (p *provider) Delete() error {
 
 func (p *provider) List() ([]byte, error) {
 	var out []byte
-	if err := checkCGroupsAndRootFulMode(p.info); err != nil {
+	if err := p.checkCGroupsAndRootFulMode(); err != nil {
 		return out, err
 	}
-	cmd := podmanCmd(providers.ListOptions(constants.ContainerName))
+	cmd := p.podmanCmd(providers.ListOptions(constants.ContainerName))
 	out, err := exec.Output(cmd)
 	if err != nil {
 		return out, err
@@ -155,27 +199,8 @@ func (p *provider) List() ([]byte, error) {
 	return out, nil
 }
 
-func getProviderInfo() (*providers.ProviderInfo, error) {
-	var initError error
-	once.Do(func() {
-		cmd := exec.Command("podman", "info", "--format", "{{.Host.Security.Rootless}}")
-		out, err := exec.Output(cmd)
-		if err != nil {
-			initError = err
-			return
-		}
-		needSudo, err := strconv.ParseBool(strings.TrimSpace(string(out)))
-		if err != nil {
-			initError = err
-			return
-		}
-		useSudo = needSudo
-	})
-	if initError != nil {
-		return nil, initError
-	}
-
-	cmd := podmanCmd([]string{"info", "--format", "json"})
+func (p *provider) fetchProviderInfo() (*providers.ProviderInfo, error) {
+	cmd := p.podmanCmd([]string{"info", "--format", "json"})
 	out, err := exec.Output(cmd)
 	if err != nil {
 		return nil, err
@@ -204,14 +229,20 @@ func getProviderInfo() (*providers.ProviderInfo, error) {
 		Rootless: res.Host.Security.Rootless,
 		CGroupV2: cGroupV2,
 	}, nil
-
 }
 
-func checkCGroupsAndRootFulMode(pInfo *providers.ProviderInfo) error {
-	if !pInfo.CGroupV2 {
+func (p *provider) checkCGroupsAndRootFulMode() error {
+	if p.info == nil {
+		info, err := p.fetchProviderInfo()
+		if err != nil {
+			return err
+		}
+		p.info = info
+	}
+	if !p.info.CGroupV2 {
 		return fmt.Errorf("podman provider requires cgroup v2")
 	}
-	if pInfo.Rootless {
+	if p.info.Rootless && !p.allowRootless {
 		return fmt.Errorf("podman provider requires rootful mode")
 	}
 	return nil
@@ -224,11 +255,97 @@ func (p *provider) String() string {
 	return "podman"
 }
 
-func podmanCmd(args []string) exec.Cmd {
-	if useSudo && runtime.GOOS == "linux" {
+func (p *provider) podmanCmd(args []string) exec.Cmd {
+	if p.useSudo && runtime.GOOS == "linux" {
 		log.Debug("Running with sudo:", "podman", strings.Join(args, " "))
 		return exec.Command("sudo", append([]string{"podman"}, args...)...)
-	} else {
-		return exec.Command("podman", args...)
 	}
+	return exec.Command("podman", args...)
+}
+
+// rootlessConfigs holds the host paths for all rootless configuration files.
+type rootlessConfigs struct {
+	microshiftConf string
+	crioConf       string
+	crunWrapper    string
+}
+
+// writeRootlessConfigs creates MicroShift, CRI-O config files and a crun
+// wrapper needed for rootless operation. The files are written to the user's
+// minc config directory (~/.config/minc/).
+func writeRootlessConfigs() (*rootlessConfigs, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(configDir, "minc")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+
+	// MicroShift config: enable KubeletInUserNamespace so the kubelet skips
+	// host-level sysctl writes and /dev/kmsg checks that fail in user namespaces.
+	msPath := filepath.Join(dir, "rootless-microshift.yaml")
+	msContent := `kubelet:
+  featureGates:
+    KubeletInUserNamespace: true
+`
+	if err := os.WriteFile(msPath, []byte(msContent), 0644); err != nil {
+		return nil, fmt.Errorf("writing microshift rootless config: %w", err)
+	}
+
+	// CRI-O config: switch cgroup manager from systemd to cgroupfs and
+	// register a custom runtime that forces crun --rootless mode.
+	// The drop-in is numbered 20- so it overrides 10-microshift.conf.
+	crioPath := filepath.Join(dir, "rootless-crio.conf")
+	crioContent := `[crio.runtime]
+cgroup_manager = "cgroupfs"
+conmon_cgroup = "pod"
+default_runtime = "crun-rootless"
+# Clear default_sysctls set by 10-microshift.conf; pinns cannot write
+# net.ipv4.ping_group_range inside rootless user namespaces.
+default_sysctls = []
+
+[crio.runtime.runtimes.crun-rootless]
+runtime_path = "/usr/local/bin/crun-rootless"
+runtime_type = "oci"
+`
+	if err := os.WriteFile(crioPath, []byte(crioContent), 0644); err != nil {
+		return nil, fmt.Errorf("writing crio rootless config: %w", err)
+	}
+
+	// crun wrapper: patch the OCI config.json to remove oomScoreAdj and set
+	// linux.rootless=true before calling crun. In user namespaces, the kernel
+	// only allows INCREASING oom_score_adj; pods requesting a lower value
+	// (e.g. -997 for Guaranteed QoS) cause crun to fail with EPERM.
+	wrapperPath := filepath.Join(dir, "crun-rootless")
+	wrapperContent := `#!/bin/sh
+# Patch OCI spec for rootless: strip oomScoreAdj and set linux.rootless.
+# Only applies to "create" / "run" subcommands that carry --bundle.
+bundle=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--bundle" ] || [ "$prev" = "-b" ]; then
+    bundle="$arg"
+    break
+  fi
+  prev="$arg"
+done
+if [ -n "$bundle" ] && [ -f "$bundle/config.json" ]; then
+  jq 'if .process then .process |= del(.oomScoreAdj) else . end
+      | if .linux then .linux.rootless = true else . end' \
+    "$bundle/config.json" > "$bundle/config.json.tmp" \
+    && mv "$bundle/config.json.tmp" "$bundle/config.json"
+fi
+exec /usr/bin/crun "$@"
+`
+	if err := os.WriteFile(wrapperPath, []byte(wrapperContent), 0755); err != nil {
+		return nil, fmt.Errorf("writing crun rootless wrapper: %w", err)
+	}
+
+	return &rootlessConfigs{
+		microshiftConf: msPath,
+		crioConf:       crioPath,
+		crunWrapper:    wrapperPath,
+	}, nil
 }

--- a/pkg/providers/register/register.go
+++ b/pkg/providers/register/register.go
@@ -4,15 +4,18 @@ import (
 	"github.com/minc-org/minc/pkg/providers"
 	"github.com/minc-org/minc/pkg/providers/moby"
 	"github.com/minc-org/minc/pkg/providers/podman"
+	"github.com/minc-org/minc/pkg/rootlessmarker"
+	"github.com/spf13/viper"
 )
 
 func Register(provider string) (providers.Provider, error) {
+	allowRootless := viper.GetBool("allow-rootless") || rootlessmarker.Present()
 	switch provider {
 	case "podman":
-		return podman.New()
+		return podman.New(allowRootless)
 	case "docker":
 		return moby.New()
 	default:
-		return podman.New()
+		return podman.New(allowRootless)
 	}
 }

--- a/pkg/providers/wait.go
+++ b/pkg/providers/wait.go
@@ -1,0 +1,13 @@
+package providers
+
+import "time"
+
+// MicroShiftServiceMaxRetries bounds how long we poll systemctl is-active for the microshift
+// unit inside the container. While the unit is "activating", is-active exits non-zero (often 3),
+// so each poll is a retry. Rootless or slow storage can keep the unit activating for many minutes.
+//
+// pkg/retry uses linear backoff: sleep = InitialDelay * attempt.
+// Total wait = InitialDelay * (1+2+...+(N-1)) = 2s * (17*18/2) = 306s ≈ 5 min.
+const MicroShiftServiceMaxRetries = 18
+
+const MicroShiftServiceInitialRetryDelay = 2 * time.Second

--- a/pkg/rootlessmarker/marker.go
+++ b/pkg/rootlessmarker/marker.go
@@ -1,0 +1,52 @@
+package rootlessmarker
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const markerFile = ".rootless-cluster"
+
+// Path returns the path to the on-disk marker, or an error if the user config dir cannot be resolved.
+func Path() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "minc", markerFile), nil
+}
+
+// Present is true when this minc cluster was created with rootless Podman (see register).
+func Present() bool {
+	p, err := Path()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(p)
+	return err == nil
+}
+
+// Set writes the marker after a successful rootless create.
+func Set() error {
+	p, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte("1\n"), 0644)
+}
+
+// Remove deletes the marker; call after a successful minc delete of a rootless cluster.
+func Remove() error {
+	p, err := Path()
+	if err != nil {
+		return err
+	}
+	err = os.Remove(p)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
## Summary

This PR adds rootless Podman support to minc, enabling `minc create` without `sudo` or root privileges via a new `--allow-rootless` flag. It resolves all blockers identified in #22.

With all changes applied, all MicroShift system pods reach `Running` status under rootless Podman on Fedora 43 / kernel 6.19 / crun 1.23.

## Problems Solved

Eight distinct issues were discovered and resolved during rootless bringup:

| # | Problem | Solution |
|---|---------|----------|
| 1 | CRI-O cgroup manager fails (`Failed to connect to bus: No medium found`) - no D-Bus user session in rootless | CRI-O drop-in (`20-rootless.conf`) switching to `cgroupfs`, overriding `10-microshift.conf` |
| 2 | IPv6 localhost resolution breaks etcd connection | `--sysctl net.ipv6.conf.all.disable_ipv6=1` at container creation |
| 3 | `oom_score_adj` writes fail with EPERM in user namespaces | `crun-rootless` wrapper strips `oomScoreAdj` from OCI spec via `jq` |
| 4 | `cpuset` cgroup controller not delegated to user sessions | Host-side systemd drop-in (documented, same as kind rootless) |
| 5 | `chown` fails with EINVAL for high OpenShift SCC UIDs | Host-side subordinate UID/GID range expansion (documented) |
| 6 | `crio-subid.service` failure inside container | No impact - subordinate IDs managed by host Podman |
| 7 | `/dev/kmsg` not accessible in rootless namespaces | Mount `/dev/null` as `/dev/kmsg` |
| 8 | Kubelet needs user namespace awareness | `KubeletInUserNamespace` feature gate via MicroShift config drop-in |

## Code Changes

| File | Change | Purpose |
|------|--------|---------|
| `cmd/minc/main.go` | Modified | `--allow-rootless` persistent flag, rootless marker lifecycle |
| `cmd/minc/config.go` | Modified | `allow-rootless` in default config |
| `pkg/providers/podman/provider.go` | Refactored | Instance fields replacing globals, rootless config generation, dynamic graph root |
| `pkg/providers/options.go` | Modified | Rootless-specific container flags and bind mounts |
| `pkg/providers/moby/provider.go` | Modified | Use shared retry constants |
| `pkg/providers/register/register.go` | Modified | Pass `allowRootless` to provider constructor |
| `pkg/providers/wait.go` | **New** | Shared MicroShift retry constants (18 retries / ~5 min) |
| `pkg/rootlessmarker/marker.go` | **New** | Persistent rootless mode marker at `~/.config/minc/.rootless-cluster` |

### Key design decisions

- **Rootless marker file**: Persists rootless mode between `create` and `delete` so subsequent commands (delete, generate-kubeconfig) work without re-specifying `--allow-rootless`.
- **Provider refactor**: Replaced global `useSudo` variable and `sync.Once` with instance fields on the provider struct, eliminating shared mutable state.
- **Dynamic storage path**: Queries Podman for the actual graph root (`Store.GraphRoot`) instead of hardcoding `/var/lib/containers/storage`, which differs in rootless mode.
- **Config file generation**: Three files (MicroShift YAML, CRI-O conf, crun wrapper) are written to `~/.config/minc/` and bind-mounted into the container at creation time.
- **Drop-in numbering**: `20-` prefix ensures rootless configs override MicroShift's `10-microshift.conf`.

## Host Prerequisites (One-Time Setup)

Four host-side changes are required before using `--allow-rootless`. Steps 1-3 require root/sudo. All settings persist across reboots.

**1. Kernel parameters (sysctl):**
```bash
sudo tee /etc/sysctl.d/99-minc-rootless.conf <<'SYSCTL'
net.ipv4.ip_forward = 1
net.ipv4.ip_unprivileged_port_start = 80
fs.inotify.max_user_instances = 1024
SYSCTL
sudo sysctl --system
```

- `ip_forward` - required for container networking (packet forwarding)
- `ip_unprivileged_port_start = 80` - allows rootless Podman to bind HTTP/HTTPS ports (80, 443)
- `max_user_instances = 1024` - increases inotify watch limit for MicroShift services

**2. Load `ip_tables` kernel module:**
```bash
sudo tee /etc/modules-load.d/minc-rootless.conf <<'MOD'
ip_tables
MOD
sudo modprobe ip_tables
```

**3. Delegate cpuset cgroup controller:**
```bash
sudo mkdir -p /etc/systemd/system/user@.service.d/
sudo tee /etc/systemd/system/user@.service.d/delegate.conf <<'CONF'
[Service]
Delegate=cpuset cpu io memory pids
CONF
sudo systemctl daemon-reload
```

**4. Expand subordinate UID/GID ranges** (for OpenShift SCC high UIDs):
```bash
sudo usermod --add-subuids 165536-1265535999 --add-subgids 165536-1265535999 $(whoami)

```

Then, as your regular user (not root), migrate Podman to pick up the new ranges:
```bash
podman system migrate
```

> **Note:** These steps are only needed once per host. After a reboot the sysctl and module settings load automatically via the files in `/etc/sysctl.d/` and `/etc/modules-load.d/`.

## Usage

```bash
# Create a rootless cluster:
minc create --allow-rootless

# Or via config (persistent):
minc config set allow-rootless true
minc create

# Delete (auto-detects rootless mode via marker):
minc delete
```

## Test Environment

| Component | Version |
|-----------|---------|
| OS | Fedora 43 |
| Kernel | 6.19.11-200.fc43.x86_64 |
| Podman | rootless mode |
| CRI-O | 1.32.8 (inside container) |
| crun | 1.23 (inside container) |
| MicroShift | 4.19 (OKD/SCOS) |

## Test Results

All 9 MicroShift system pods reach `Running` status under rootless Podman:

```
NAMESPACE              NAME                                       READY   STATUS    AGE
kube-flannel           kube-flannel-ds-xxxxx                      1/1     Running   ...
kube-proxy             kube-proxy-xxxxx                           1/1     Running   ...
kube-system            csi-snapshot-controller-xxxxx              1/1     Running   ...
openshift-dns          dns-default-xxxxx                          2/2     Running   ...
openshift-dns          node-resolver-xxxxx                        1/1     Running   ...
openshift-ingress      router-default-xxxxx                       1/1     Running   ...
openshift-service-ca   service-ca-xxxxx                           1/1     Running   ...
```

## Future Work

- Automated host prerequisite checks with actionable error messages
- macOS support (Podman Machine VM prerequisites)
- Podman Desktop integration ([podman-desktop#2861](https://github.com/podman-desktop/podman-desktop/issues/2861), [podman-desktop#15302](https://github.com/podman-desktop/podman-desktop/issues/15302))
- Upstream CRI-O/crun improvements (automatic cgroupfs fallback, `--rootless` flag fixing `oom_score_adj`)

## References

- [Kubernetes: Running Kubelet in User Namespaces](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-in-userns/)
- [kind: Rootless mode](https://kind.sigs.k8s.io/docs/user/rootless/)
- [kind: KubeletInUserNamespace config](https://github.com/kubernetes-sigs/kind/blob/1e95d05eeccdf615e24d7af11276e2954fe265a2/pkg/cluster/internal/kubeadm/config.go#L498)
- [user_namespaces(7)](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)

Fixes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent --allow-rootless option to enable rootless container operation and related runtime behavior.
  * New configuration settings to control container storage and rootless artifacts.

* **Improvements**
  * More robust service startup detection with configurable retry/backoff parameters.
  * Generated config now omits settings left at their defaults.

* **Documentation**
  * Expanded Linux installation and a new "Rootless Mode" section with prerequisites and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->