### PR TITLE
add "-sSf" flags to curl install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ In Linux, minc require sudo permission to run podman command because it is not w
 Check: https://github.com/minc-org/minc/issues/22
 
 ```bash
-curl -L -o minc  https://github.com/minc-org/minc/releases/latest/download/minc_linux_amd64
+curl -LsSf -o minc https://github.com/minc-org/minc/releases/latest/download/minc_linux_amd64
 chmod +x minc
 ```
 
 #### Mac
 ```bash
-curl -L -o minc  https://github.com/minc-org/minc/releases/latest/download/minc_darwin_arm64
+curl -LsSf -o minc https://github.com/minc-org/minc/releases/latest/download/minc_darwin_arm64
 chmod +x minc
 ```
 
 #### Windows
 ```bash
-curl.exe -L -o minc.exe  https://github.com/minc-org/minc/releases/latest/download/minc.exe
+curl.exe -LsSf -o minc.exe https://github.com/minc-org/minc/releases/latest/download/minc.exe
 ```
 
 ## Usage


### PR DESCRIPTION
```
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
```

- Add `-sSf` to all three `curl` install commands in the README
- Without `-f`, `curl` exits 0 on HTTP errors (e.g. 404) and writes the error page HTML into the output file — a user could then `chmod +x` and try to run a corrupt binary
- `-s` suppresses the progress bar, `-S` re-enables error messages that `-s` would otherwise hide, and `-f` fails fast on server errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use more robust download commands that follow redirects, fail on HTTP/network errors, and suppress non-essential output (applies to all supported platforms, including Windows), improving reliability and clearer failure feedback during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->